### PR TITLE
Feature/optimize wasm drawing

### DIFF
--- a/wasm/hal-wasm.go
+++ b/wasm/hal-wasm.go
@@ -8,9 +8,10 @@ import (
 const MAX_FRAME_COUNT = 32
 
 type WASMHAL struct {
-	keyCombo     uint32
-	canvas       Canvas
-	lastSetColor anotherworld.Color
+	keyCombo          uint32
+	canvas            Canvas
+	lastSetColor      anotherworld.Color
+	lastSillyChecksum uint32
 }
 
 func buildWASMHAL() *WASMHAL {
@@ -29,7 +30,22 @@ func (render *WASMHAL) updateKeyStateFrom(keyMap *map[uint32]bool) {
 	}
 }
 
+func sillyChecksum(buffer [anotherworld.WIDTH * anotherworld.HEIGHT]anotherworld.Color) uint32 {
+	ret := uint32(0)
+	for i := 0; i < int(anotherworld.WIDTH*anotherworld.HEIGHT); i++ {
+		ret = uint32(ret + uint32(buffer[i].R))
+	}
+	return ret
+}
+
 func (render *WASMHAL) BlitPage(buffer [anotherworld.WIDTH * anotherworld.HEIGHT]anotherworld.Color, posX, posY int) {
+	currentCheckSum := sillyChecksum(buffer)
+	if currentCheckSum == render.lastSillyChecksum {
+		logger.Debug(">DUP FRAME")
+		return
+	}
+	render.lastSillyChecksum = currentCheckSum
+
 	//see https://github.com/golang/go/wiki/InterfaceSlice
 	var a [anotherworld.WIDTH * anotherworld.HEIGHT]int
 	offset := 0

--- a/wasm/hal-wasm.go
+++ b/wasm/hal-wasm.go
@@ -33,7 +33,7 @@ func (render *WASMHAL) updateKeyStateFrom(keyMap *map[uint32]bool) {
 func sillyChecksum(buffer [anotherworld.WIDTH * anotherworld.HEIGHT]anotherworld.Color) uint32 {
 	ret := uint32(0)
 	for i := 0; i < int(anotherworld.WIDTH*anotherworld.HEIGHT); i++ {
-		ret = uint32(ret + uint32(buffer[i].R))
+		ret = uint32(ret + uint32(buffer[i].R) + uint32(buffer[i].G))
 	}
 	return ret
 }

--- a/wasm/js-canvas.go
+++ b/wasm/js-canvas.go
@@ -15,24 +15,10 @@ func GetCanvas(domElementId string) Canvas {
 	canvasElement := js.Global().Get("document").Call("getElementById", domElementId)
 	context2d := canvasElement.Call("getContext", "2d")
 
-	canvas := Canvas{
+	return Canvas{
 		context2d: context2d,
 	}
-
-	return canvas
 }
-
-// Notes:
-// Consider drawImage, if we can generate the correct format to output in 1 call.
-// https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-// OR
-// access the canvas pixel data directly might be faster - at least for unscaled output
-//  var id = ctx.getImageData(0, 0, canvasWidth, canvasHeight)
-//  var pixels = id.data
-//  pixels[0] = 0
-//  pixels[1] = 255
-//  pixels[2] = 255
-//  pixels[3] = 255
 
 func (c Canvas) SetColor(color anotherworld.Color) {
 	c.context2d.Set("fillStyle", fmt.Sprintf("rgb(%d, %d, %d)", color.R, color.G, color.B))

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -9,21 +9,7 @@
   const ctx = canvas.getContext('2d');
   let lastBlitSum;
 
-  function checksum(buffer) {
-    let sum = 0;
-    buffer.forEach((pixel) => {
-      sum = (sum + pixel) & 0x7FFFFFFF;
-    });
-    return sum;
-  }
-
   ctx.blit = function(buffer) {
-    const currentChecksum = checksum(buffer);
-    if (lastBlitSum === currentChecksum) {
-      //screen did not change, do not render it!
-      return;
-    }
-    lastBlitSum = currentChecksum;
     let offset = 0;
     let lastPixel = '';
     buffer.forEach((pixel) => {


### PR DESCRIPTION
detect that the current frame to blit did not change - thus no need to draw.

the change detection is very silly (thus the name), simple add of R and B pixels